### PR TITLE
temporary keccak-256 implementation

### DIFF
--- a/common/hash.c
+++ b/common/hash.c
@@ -52,6 +52,9 @@ const YH_INTERNAL EVP_MD *get_hash(hash_t hash) {
     case _SHA256:
       return EVP_sha256();
 
+    case _KECCAK256:
+      return EVP_sha256();
+
     case _SHA384:
       return EVP_sha384();
 
@@ -74,6 +77,9 @@ LPCWSTR YH_INTERNAL get_hash(hash_t hash) {
       return BCRYPT_SHA1_ALGORITHM;
 
     case _SHA256:
+      return BCRYPT_SHA256_ALGORITHM;
+
+    case _KECCAK256:
       return BCRYPT_SHA256_ALGORITHM;
 
     case _SHA384:

--- a/common/hash.h
+++ b/common/hash.h
@@ -35,6 +35,7 @@ typedef enum {
   _NONE,
   _SHA1,
   _SHA256,
+  _KECCAK256,
   _SHA384,
   _SHA512,
 } hash_t;

--- a/common/util.c
+++ b/common/util.c
@@ -442,6 +442,7 @@ bool algo2type(yh_algorithm algorithm, yh_object_type *type) {
     case YH_ALGO_RSA_OAEP_SHA384:
     case YH_ALGO_RSA_OAEP_SHA512:
     case YH_ALGO_EC_ECDSA_SHA256:
+    case YH_ALGO_EC_ECDSA_KECCAK256:
     case YH_ALGO_EC_ECDSA_SHA384:
     case YH_ALGO_EC_ECDSA_SHA512:
     case YH_ALGO_EC_ED25519:

--- a/lib/yubihsm.h
+++ b/lib/yubihsm.h
@@ -490,6 +490,8 @@ typedef enum {
   YH_ALGO_RSA_PKCS1_DECRYPT = 48,
   /// ec-p256-yubico-authentication
   YH_ALGO_EC_P256_YUBICO_AUTHENTICATION = 49,
+  // ecdsa-keccak256
+  YH_ALGO_EC_ECDSA_KECCAK256 = 50,
 } yh_algorithm;
 
 /**
@@ -655,6 +657,7 @@ static const struct {
   {"ecdsa-sha256", YH_ALGO_EC_ECDSA_SHA256},
   {"ecdsa-sha384", YH_ALGO_EC_ECDSA_SHA384},
   {"ecdsa-sha512", YH_ALGO_EC_ECDSA_SHA512},
+  {"ecdsa-keccak256", YH_ALGO_EC_ECDSA_KECCAK256},
   {"eck256", YH_ALGO_EC_K256},
   {"ecp224", YH_ALGO_EC_P224},
   {"ecp256", YH_ALGO_EC_P256},


### PR DESCRIPTION
Just a temporary keccak-256 implementation that allows for use of Keccak256 encoded hashes (32 byte length) to be passed directly to YubiHSM key for ECDSA signing.